### PR TITLE
Restrict dashboard sections based on permissions

### DIFF
--- a/app/dashboard/colaboradores/page.tsx
+++ b/app/dashboard/colaboradores/page.tsx
@@ -1,10 +1,16 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
 import ColaboradoresSection from "@/components/colaboradores-section"
+import { PermissionGuard } from "@/components/permission-guard"
 
 export default function ColaboradoresPage() {
   return (
     <DashboardLayout>
-      <ColaboradoresSection />
+      <PermissionGuard
+        allowedPermissions={["Admin", "Editor"]}
+        fallbackDescription="Somente usuários com permissão de Admin ou Editor podem visualizar e gerenciar colaboradores."
+      >
+        <ColaboradoresSection />
+      </PermissionGuard>
     </DashboardLayout>
   )
 }

--- a/app/dashboard/configuracoes/page.tsx
+++ b/app/dashboard/configuracoes/page.tsx
@@ -1,10 +1,16 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { ConfiguracoesSection } from "@/components/configuracoes-section"
+import { PermissionGuard } from "@/components/permission-guard"
 
 export default function ConfiguracoesPage() {
   return (
     <DashboardLayout>
-      <ConfiguracoesSection />
+      <PermissionGuard
+        allowedPermissions={["Admin"]}
+        fallbackDescription="Somente usuários com permissão de Admin podem alterar as configurações do sistema."
+      >
+        <ConfiguracoesSection />
+      </PermissionGuard>
     </DashboardLayout>
   )
 }

--- a/app/dashboard/usuarios/page.tsx
+++ b/app/dashboard/usuarios/page.tsx
@@ -1,10 +1,16 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
+import { PermissionGuard } from "@/components/permission-guard"
 import { UsuariosSection } from "@/components/usuarios-section"
 
 export default function UsuariosPage() {
   return (
     <DashboardLayout>
-      <UsuariosSection />
+      <PermissionGuard
+        allowedPermissions={["Admin", "Editor"]}
+        fallbackDescription="Somente usuários com permissão de Admin ou Editor podem administrar outras contas de usuário."
+      >
+        <UsuariosSection />
+      </PermissionGuard>
     </DashboardLayout>
   )
 }

--- a/components/permission-guard.tsx
+++ b/components/permission-guard.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo } from "react"
+import type { ReactNode } from "react"
+import { Loader2, Lock } from "lucide-react"
+
+import { useAuth } from "@/contexts/AuthContext"
+import type { Usuario } from "@/types/auth"
+
+interface PermissionGuardProps {
+  allowedPermissions: Array<Usuario["permissao"]>
+  children: ReactNode
+  fallbackTitle?: string
+  fallbackDescription?: string
+  fallbackActions?: ReactNode
+}
+
+export function PermissionGuard({
+  allowedPermissions,
+  children,
+  fallbackTitle = "Acesso restrito",
+  fallbackDescription = "Você não tem permissão para acessar esta seção. Entre em contato com um administrador caso precise de acesso.",
+  fallbackActions,
+}: PermissionGuardProps) {
+  const { user, loading } = useAuth()
+
+  const userPermission = user?.usuario?.permissao
+  const hasPermission = useMemo(
+    () => (userPermission ? allowedPermissions.includes(userPermission) : false),
+    [allowedPermissions, userPermission],
+  )
+
+  if (loading) {
+    return (
+      <div className="min-h-[50vh] flex flex-col items-center justify-center gap-3 text-muted-foreground">
+        <Loader2 className="h-8 w-8 animate-spin" />
+        <p>Verificando permissões...</p>
+      </div>
+    )
+  }
+
+  if (!hasPermission) {
+    return (
+      <div className="min-h-[50vh] flex flex-col items-center justify-center gap-6 rounded-lg border border-dashed border-border bg-muted/30 p-10 text-center">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Lock className="h-8 w-8" />
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-foreground">{fallbackTitle}</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            {fallbackDescription}
+          </p>
+          {userPermission && (
+            <p className="text-xs uppercase tracking-wide text-muted-foreground/80">
+              Permissão atual: {userPermission}
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground/80">
+            Permissões necessárias: {allowedPermissions.join(" • ")}
+          </p>
+        </div>
+
+        {fallbackActions}
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,11 +1,20 @@
 "use client"
+import type { ReactNode } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/contexts/AuthContext"
+import type { Usuario } from "@/types/auth"
 
-const menuItems = [
+type MenuItem = {
+  name: string
+  href: string
+  icon: ReactNode
+  requiredPermissions?: Array<Usuario["permissao"]>
+}
+
+const menuItems: MenuItem[] = [
   {
     name: "Consultas",
     href: "/dashboard/consultas",
@@ -33,6 +42,7 @@ const menuItems = [
         />
       </svg>
     ),
+    requiredPermissions: ["Admin", "Editor"],
   },
   {
     name: "Usuários",
@@ -47,7 +57,7 @@ const menuItems = [
         />
       </svg>
     ),
-    adminOnly: true,
+    requiredPermissions: ["Admin", "Editor"],
   },
   {
     name: "Configurações",
@@ -63,7 +73,7 @@ const menuItems = [
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
     ),
-    adminOnly: true,
+    requiredPermissions: ["Admin"],
   },
 ]
 
@@ -71,11 +81,18 @@ export function Sidebar() {
   const pathname = usePathname()
   const { user, logout } = useAuth()
 
-  const filteredMenuItems = menuItems.filter(item => {
-    if (item.adminOnly) {
-      return user?.usuario?.permissao === 'Admin'
+  const userPermission = user?.usuario?.permissao
+
+  const filteredMenuItems = menuItems.filter((item) => {
+    if (!item.requiredPermissions) {
+      return true
     }
-    return true
+
+    if (!userPermission) {
+      return false
+    }
+
+    return item.requiredPermissions.includes(userPermission)
   })
 
   const handleLogout = () => {


### PR DESCRIPTION
## Summary
- add a reusable client-side PermissionGuard component to centralize permission checks and messaging
- wrap the colaboradores, usuários and configurações dashboard pages with the guard so Visualizador accounts see a locked state
- filter sidebar navigation items according to the current usuário.permissao to hide links a user cannot access

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d14ff5aad08333a72d1f9de9a9fc3a